### PR TITLE
Logic for rhel vdc subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ $ ./hcs-collector.py process
 Max Concurrent RHEL On-Demand, referrent to ..: 2022-03
 On-Demand, Physical Node .....................: 973
 On-Demand, Virtual Node ......................: 5092
+Virtual Data Center, Virtual Node ............: 3742
 Unknown ......................................: 0
 
 ## RHEL Add-ons
@@ -168,12 +169,17 @@ On-Demand, Virtualization Sockets ............: 192
 On-Demand, JBoss EAP Cores ...................: 312
 On-Demand, JWS Cores .........................: 474
 
+## RHEL Virtual Data Center
+
+Virtual Data Center, Hypervisor ..............: 198
+Virtual Data Center, Hypervisor Sockets ......: 766
 
 ## RHEL On-Demand
 
 Max Concurrent RHEL On-Demand, referrent to ..: 2022-04
 On-Demand, Physical Node .....................: 978
 On-Demand, Virtual Node ......................: 5500
+Virtual Data Center, Virtual Node ............: 3787
 Unknown ......................................: 0
 
 ## RHEL Add-ons
@@ -189,6 +195,11 @@ On-Demand, Virtualization Sockets ............: 192
 
 On-Demand, JBoss EAP Cores ...................: 324
 On-Demand, JWS Cores .........................: 496
+
+## RHEL Virtual Data Center
+
+Virtual Data Center, Hypervisor ..............: 198
+Virtual Data Center, Hypervisor Sockets ......: 766
 ```
 
 Another option is to use the --tag to break down the overall usage by tag.  This is so that you can break down your usage by environment, or business unit or any other criteria, and can help with internal cross charging.

--- a/execution/execution.py
+++ b/execution/execution.py
@@ -13,6 +13,7 @@ from execution import process_mw
 from execution import process_rhel
 from execution import process_virt
 from execution import process_rhel_addons
+from execution import process_rhel_vdc
 from execution import collect_tags
 
 
@@ -125,6 +126,9 @@ def generate_report(path_to_csv_dir, csv_files_list, path_to_json_dir, json_file
     print("## Middleware")
     print("")
     process_mw.ondemand_mw_from_json(path_to_json_dir, json_files_list, tag)
+    print("## RHEL Virtual Data Center")
+    print("")
+    process_rhel_vdc.virtualdatacenter_rhel(path_to_csv_dir, csv_files_list, tag)
 
 
 

--- a/execution/process_rhel.py
+++ b/execution/process_rhel.py
@@ -17,6 +17,7 @@ def ondemand_rhel(path_to_csv_dir, csv_files_list, tag):
     # max values for the month
     rhel_physical = 0
     rhel_virtual = 0
+    rhel_vdc = 0
     unknown = 0
     max_by_tag = {}
 
@@ -25,6 +26,7 @@ def ondemand_rhel(path_to_csv_dir, csv_files_list, tag):
         #counted values for this sheet/day
         stage_rhel_physical = 0
         stage_rhel_virtual = 0
+        stage_rhel_vdc = 0
         stage_unknown = 0
         stage_by_tag = {}
 
@@ -35,6 +37,7 @@ def ondemand_rhel(path_to_csv_dir, csv_files_list, tag):
                 # print(row)
                 infrastructure_type = row[21]
                 installed_product = row[35]
+                hypervisor_fqdn = row[38]
                 vmtags = row[len(row)-1]
                 tagvalue=""
                 if (tag != "none"):
@@ -48,6 +51,8 @@ def ondemand_rhel(path_to_csv_dir, csv_files_list, tag):
 
                     if infrastructure_type == "physical":
                         stage_rhel_physical = stage_rhel_physical + 1
+                    elif (infrastructure_type == "virtual") and (hypervisor_fqdn.startswith('virt-who-')):
+                        stage_rhel_vdc = stage_rhel_vdc + 1
                     elif infrastructure_type == "virtual":
                         stage_rhel_virtual = stage_rhel_virtual + 1
                     else:
@@ -59,7 +64,10 @@ def ondemand_rhel(path_to_csv_dir, csv_files_list, tag):
 
         if stage_rhel_virtual > rhel_virtual:
             rhel_virtual = stage_rhel_virtual
-        
+
+        if stage_rhel_vdc > rhel_vdc:
+            rhel_vdc = stage_rhel_vdc
+
         if stage_unknown > unknown:
             unknown = stage_unknown
         
@@ -76,6 +84,7 @@ def ondemand_rhel(path_to_csv_dir, csv_files_list, tag):
     if (tag != "none"):
         for tagvalue in max_by_tag:
             util.pretty_print(2,tagvalue, max_by_tag[tagvalue]['virtual'])
+    print("Virtual Data Center, Virtual Node ............: {}".format(rhel_vdc))
     print("Unknown ......................................: {}".format(unknown))
     print("")
 

--- a/execution/process_rhel_vdc.py
+++ b/execution/process_rhel_vdc.py
@@ -1,14 +1,10 @@
 import csv
 from execution import util
 
-def virtualdatacenter_rhel(path_to_csv_dir, csv_files_list):
+def virtualdatacenter_rhel(path_to_csv_dir, csv_files_list, tag):
     """
     TODO
     """
-
-    # for debug purposes
-    # print(path_to_csv_dir)
-    # print(csv_files_list)
 
     CURRENT_TIMEFRAME_YEAR = path_to_csv_dir.split("/")[4]
     CURRENT_TIMEFRAME_MONTH = path_to_csv_dir.split("/")[5]
@@ -16,7 +12,6 @@ def virtualdatacenter_rhel(path_to_csv_dir, csv_files_list):
 
     for sheet in csv_files_list:
 
-        # adding virt_who and stage_virt_who
         virt_who = 0
         stage_virt_who = 0
         vdc_sockets = 0
@@ -38,12 +33,10 @@ def virtualdatacenter_rhel(path_to_csv_dir, csv_files_list):
                         hypervisor_number_of_sockets = int(row[11])
                     stage_vdc_sockets = stage_vdc_sockets + hypervisor_number_of_sockets
 
-    # adding virt-who
     if stage_virt_who > virt_who:
         virt_who = stage_virt_who
         stage_virt_who = 0
 
-    # adding vdc sockets
     if stage_vdc_sockets > vdc_sockets:
         vdc_sockets = stage_vdc_sockets
         stage_vdc_sockets = 0

--- a/execution/process_rhel_vdc.py
+++ b/execution/process_rhel_vdc.py
@@ -1,0 +1,53 @@
+import csv
+from execution import util
+
+def virtualdatacenter_rhel(path_to_csv_dir, csv_files_list):
+    """
+    TODO
+    """
+
+    # for debug purposes
+    # print(path_to_csv_dir)
+    # print(csv_files_list)
+
+    CURRENT_TIMEFRAME_YEAR = path_to_csv_dir.split("/")[4]
+    CURRENT_TIMEFRAME_MONTH = path_to_csv_dir.split("/")[5]
+    CURRENT_TIMEFRAME = CURRENT_TIMEFRAME_YEAR + "-" + CURRENT_TIMEFRAME_MONTH
+
+    for sheet in csv_files_list:
+
+        # adding virt_who and stage_virt_who
+        virt_who = 0
+        stage_virt_who = 0
+        vdc_sockets = 0
+        stage_vdc_sockets = 0
+
+        with open(path_to_csv_dir + "/" + sheet, "r") as file_obj:
+            csv_file = csv.reader(file_obj)
+            for row in csv_file:
+                # print(row)
+
+                infrastructure_type = row[21]
+                number_of_guests = row[40]
+
+                if (infrastructure_type == "physical") and (number_of_guests.isnumeric()):
+                    stage_virt_who = stage_virt_who + 1
+
+                    hypervisor_number_of_sockets = 0
+                    if (row[11].isnumeric()):
+                        hypervisor_number_of_sockets = int(row[11])
+                    stage_vdc_sockets = stage_vdc_sockets + hypervisor_number_of_sockets
+
+    # adding virt-who
+    if stage_virt_who > virt_who:
+        virt_who = stage_virt_who
+        stage_virt_who = 0
+
+    # adding vdc sockets
+    if stage_vdc_sockets > vdc_sockets:
+        vdc_sockets = stage_vdc_sockets
+        stage_vdc_sockets = 0
+
+    print("Virtual Data Center, Hypervisor ..............: {}".format(virt_who))
+    print("Virtual Data Center, Hypervisor Sockets ......: {}".format(vdc_sockets))
+    print("")


### PR DESCRIPTION
Checking if RHEL virtual guest runs on a hypervisor host correctly reported by virt-who should be treated as virtual guest covered by Virtual Data Center subscription. Proper identification is needed for accurate reporting in a scenario where RHEL Virtual Data Center subscription is present alongside HCS On-Demand. If an RHEL virtual guest runs on a properly subscribed VDC host, this guest shouldn't be counted towards On-Demand, RHEL consumption.